### PR TITLE
Allow exec-path search to find external program

### DIFF
--- a/wcheck-mode.el
+++ b/wcheck-mode.el
@@ -2022,9 +2022,10 @@ a (valid) value for the KEY then query the value from
 (defun wcheck--program-executable-p (program)
   "Return t if PROGRAM is executable regular file."
   (and (stringp program)
-       (file-regular-p program)
-       (file-executable-p program)
-       t))
+       (or (and (file-regular-p program)
+                (file-executable-p program))
+           (executable-find program))))
+
 
 
 (defun wcheck--program-configured-p (language)


### PR DESCRIPTION
It's convenient to be able to specify the checker program as simply "aspell" if it's in the `exec-path`.