### PR TITLE
Fix `wcheck--language-exists-p` if executable does not exist

### DIFF
--- a/wcheck-mode.el
+++ b/wcheck-mode.el
@@ -2023,7 +2023,8 @@ a (valid) value for the KEY then query the value from
   "Return non-nil if PROGRAM is executable regular file."
   (when (stringp program)
     (let ((f (executable-find program)))
-      (and (file-regular-p f)
+      (and f
+           (file-regular-p f)
            (file-executable-p f)))))
 
 


### PR DESCRIPTION
The function `executable-find` might return nil if `program` does not
exist. In this case `file-regular-p` raises a nil error. We now check
for `nil` explicitly.